### PR TITLE
Implement file seek reset in upload route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ app = FastAPI()
 @app.post("/upload/")
 async def upload_file(file: UploadFile = File(...)):
     contents = await file.read()
+    file.file.seek(0)
     result = analyse_verzuim(file.filename, contents)
     return JSONResponse(content=result)
 


### PR DESCRIPTION
## Summary
- add `.gitignore` for bytecode and test caches
- reset file pointer after reading upload in `/upload` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755c5bb8c4832dbad468504841c2aa