### PR TITLE
Add batch upload route and extend tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import JSONResponse
-from verzuimanalyse import analyse_verzuim
+from typing import List
+
+from verzuimanalyse import analyse_verzuim, analyse_meerdere
 from legalcheck import legalcheck
 
 app = FastAPI()
@@ -9,6 +11,16 @@ app = FastAPI()
 async def upload_file(file: UploadFile = File(...)):
     contents = await file.read()
     result = analyse_verzuim(file.filename, contents)
+    return JSONResponse(content=result)
+
+
+@app.post("/batch_upload/")
+async def batch_upload(files: List[UploadFile] = File(...)):
+    contents = []
+    for f in files:
+        data = await f.read()
+        contents.append((f.filename, data))
+    result = analyse_meerdere(contents)
     return JSONResponse(content=result)
 
 @app.post("/legalcheck/")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -11,6 +11,16 @@ def test_upload_route_returns_empty_dict(tmp_path):
     assert response.json() == {}
 
 
+def test_batch_upload_returns_empty_list(tmp_path):
+    files = [
+        ("files", ("dummy1.txt", b"data1", "text/plain")),
+        ("files", ("dummy2.txt", b"data2", "text/plain")),
+    ]
+    response = client.post("/batch_upload/", files=files)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 def test_legalcheck_route_with_keywords(tmp_path):
     text = "Dit document gaat over ontslag en verzuim en heeft voldoende lengte."
     response = client.post("/legalcheck/", files={"file": ("dummy.txt", text.encode(), "text/plain")})
@@ -20,3 +30,4 @@ def test_legalcheck_route_with_keywords(tmp_path):
     assert "ontslag" in data["herkenning_kernwoorden"]
     assert "verzuim" in data["herkenning_kernwoorden"]
     assert data["legal_markdown"].startswith("## Juridische Analyse")
+


### PR DESCRIPTION
## Summary
- implement `/batch_upload/` endpoint using `analyse_meerdere`
- extend route tests to cover batch uploading

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx<0.24`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755c4b51d8832da55b626c490f283f