### PR TITLE
Add batch upload and text analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Deze FastAPI-module ondersteunt:
 - Upload van verzuimdocumenten
 - Analyse met benchmark, risiconiveau en aanbevelingen
 - PDF-rapportgeneratie uit markdown
-- Batchverwerking van meerdere bestanden
+- Batchverwerking van meerdere bestanden via `/batch_upload/`
+- Verkorte tekstanalyse via `/analyse_text/`
 - Grafiekoutput als PNG.
 
 ## Starten

--- a/main.py
+++ b/main.py
@@ -1,15 +1,34 @@
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, UploadFile, Form
 from fastapi.responses import JSONResponse
-from verzuimanalyse import analyse_verzuim
+from typing import List
+from verzuimanalyse import analyse_verzuim, analyse_meerdere
 from legalcheck import legalcheck
 
 app = FastAPI()
+
 
 @app.post("/upload/")
 async def upload_file(file: UploadFile = File(...)):
     contents = await file.read()
     result = analyse_verzuim(file.filename, contents)
     return JSONResponse(content=result)
+
+
+@app.post("/analyse_text/")
+async def analyse_text(text: str = Form(...)):
+    result = analyse_verzuim(input_text=text)
+    return JSONResponse(content=result)
+
+
+@app.post("/batch_upload/")
+async def batch_upload(files: List[UploadFile] = File(...)):
+    file_data = []
+    for upload in files:
+        contents = await upload.read()
+        file_data.append((upload.filename, contents))
+    result = analyse_meerdere(file_data)
+    return JSONResponse(content=result)
+
 
 @app.post("/legalcheck/")
 async def upload_legal(file: UploadFile = File(...)):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4,11 +4,16 @@ from main import app
 client = TestClient(app)
 
 
-def test_upload_route_returns_empty_dict(tmp_path):
+def test_upload_route_returns_analysis(tmp_path):
     file_content = b"dummy content for upload"
-    response = client.post("/upload/", files={"file": ("dummy.txt", file_content, "text/plain")})
+    response = client.post(
+        "/upload/",
+        files={"file": ("dummy.txt", file_content, "text/plain")},
+    )
     assert response.status_code == 200
-    assert response.json() == {}
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "verkorte_analyse" in data
 
 
 def test_legalcheck_route_with_keywords(tmp_path):
@@ -20,3 +25,27 @@ def test_legalcheck_route_with_keywords(tmp_path):
     assert "ontslag" in data["herkenning_kernwoorden"]
     assert "verzuim" in data["herkenning_kernwoorden"]
     assert data["legal_markdown"].startswith("## Juridische Analyse")
+
+
+def test_batch_upload_route_returns_list(tmp_path):
+    file1 = b"first file"
+    file2 = b"second file"
+    response = client.post(
+        "/batch_upload/",
+        files=[
+            ("files", ("a.txt", file1, "text/plain")),
+            ("files", ("b.txt", file2, "text/plain")),
+        ],
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert all(item.get("status") == "ok" for item in data)
+
+
+def test_analyse_text_endpoint():
+    response = client.post("/analyse_text/", data={"text": "een korte analyse"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"

--- a/verzuimanalyse.py
+++ b/verzuimanalyse.py
@@ -1,8 +1,41 @@
-def analyse_verzuim(filename, contents, sbi_code='6420', periode='2025KW2'):
-    return {}
+"""Vereenvoudigde verzuimanalyse.
+
+Deze functie kan zowel een geïntegreerd tekstveld als een bestand analyseren.
+Wanneer er geen tekst beschikbaar is, wordt een melding teruggegeven. De analyse
+beperkt zich tot een woordentelling als voorbeeld van een verkorte analyse.
+"""
+
+def analyse_verzuim(
+    filename: str | None = None,
+    contents: bytes | None = None,
+    input_text: str | None = None,
+    sbi_code: str = "6420",
+    periode: str = "2025KW2",
+) -> dict:
+    text = ""
+    if input_text:
+        text = input_text
+    elif contents:
+        try:
+            text = contents.decode("utf-8", errors="ignore")
+        except Exception:
+            text = ""
+
+    if not text:
+        return {"status": "geen input", "advies": "Geen tekst beschikbaar voor analyse."}
+
+    word_count = len(text.split())
+    return {"status": "ok", "verkorte_analyse": f"Ontvangen tekst bevat {word_count} woorden."}
 
 def analyse_meerdere(files):
-    return []
+    """Analyseer meerdere bestanden en verzamel de resultaten."""
+    results = []
+    for name, data in files:
+        try:
+            results.append(analyse_verzuim(name, data))
+        except Exception as exc:
+            results.append({"filename": name, "error": str(exc)})
+    return results
 
 def genereer_pdf(markdown):
     from weasyprint import HTML


### PR DESCRIPTION
## Summary
- enhance README with API endpoints for batch and text analysis
- add text support and batch handling in `analyse_verzuim`
- expose `/analyse_text/` and `/batch_upload/` endpoints in FastAPI app
- extend API tests for new routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875569d9da8832dace1c5910806bdfc