### PR TITLE
Extend legalcheck with MSG support and dynamic questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Deze repository bevat een kleine FastAPI-applicatie die HR-processen ondersteunt
 
 2. **Juridische check** (`legalcheck.py`)
    - Controleer teksten of bestanden op juridische kernwoorden en begrippen.
-   - Bepaal de complexiteit van een casus en geef advies en een actieplan.
+   - Bepaal de complexiteit van een casus en geef advies, actieplan en vervolgvragen.
+   - Ondersteunt ook Outlook `.msg` bestanden die automatisch naar tekst worden geconverteerd.
    - Geeft een overzicht van relevante bronnen uit bijvoorbeeld wetten.nl of rijksoverheid.nl.
 
 De API definieert twee endpoints in `main.py`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ weasyprint
 matplotlib
 python-multipart
 requests
+extract_msg
+httpx>=0.24,<0.26

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -52,6 +52,28 @@ def test_legalcheck_route_with_keywords(tmp_path):
     assert "ontslag" in data["herkenning_kernwoorden"]
     assert "verzuim" in data["herkenning_kernwoorden"]
     assert data["legal_markdown"].startswith("## Juridische Analyse")
+    assert data["verdiepende_vragen"]
+    assert sum(len(h) for h in data["bronnen"].values()) >= 1
+
+
+def test_legalcheck_accepts_msg_file(monkeypatch):
+    from types import SimpleNamespace
+    import legalcheck
+
+    class DummyMsg:
+        def __init__(self, path):
+            self.subject = "Test"
+            self.body = "Dit bericht noemt ontslag en is lang genoeg."
+
+    monkeypatch.setattr(legalcheck, "extract_msg", SimpleNamespace(Message=DummyMsg))
+    response = client.post(
+        "/legalcheck/",
+        files={"file": ("dummy.msg", b"binary", "application/vnd.ms-outlook")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["herkenning_kernwoorden"]
 
 
 def test_upload_route_pdf_output(tmp_path):


### PR DESCRIPTION
## Summary
- convert Outlook `.msg` files to text in `legalcheck`
- always return at least one law reference and generate follow-up questions
- expose questions and updated sources in API responses
- document `.msg` support
- test `.msg` handling and new response fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779f94c5ac832d8da96d6aec5d7374