### PR TITLE
Implement semantic agent selection

### DIFF
--- a/Agents/Absenceagent/verzuim.py
+++ b/Agents/Absenceagent/verzuim.py
@@ -1,6 +1,25 @@
 """Functies voor het behandelen van verzuimcasuïstiek en vragen."""
 from typing import Optional
 
+# Kernwoorden die semantisch gerelateerd zijn aan verzuim. Worden gebruikt om
+# te bepalen of deze module relevant is voor een binnengekomen vraag.
+TRIGGERS = {
+    "verzuim",
+    "ziekte",
+    "absentie",
+    "re-integratie",
+    "ziekmelding",
+    "poortwachter",
+    "arbodienst",
+    "arbeidsongeschiktheid",
+}
+
+
+def match_terms(text: str) -> bool:
+    """Return ``True`` if the text is gerelateerd aan verzuim."""
+    lower = text.lower()
+    return any(t in lower for t in TRIGGERS)
+
 
 def beantwoord_vraag(vraag: str, dossier: Optional[str] = None) -> str:
     """Geef flexibel advies bij een verzuimvraag."""

--- a/Agents/Analysisagent/analysis.py
+++ b/Agents/Analysisagent/analysis.py
@@ -6,6 +6,26 @@ from datetime import datetime
 import random
 from utils.file_utils import append_row, LOG_FILE
 
+# Kernwoorden die verwijzen naar algemene analysefuncties. Deze lijst wordt
+# gebruikt om op basis van semantiek het juiste onderdeel aan te roepen.
+TRIGGERS = {
+    "analyse",
+    "rapport",
+    "spp",
+    "9 box",
+    "9-box",
+    "benchmark",
+    "trend",
+    "data",
+    "risicoanalyse",
+}
+
+
+def match_terms(text: str) -> bool:
+    """Return ``True`` if the text lijkt te gaan over data- of dossieranalyse."""
+    lower = text.lower()
+    return any(t in lower for t in TRIGGERS)
+
 
 def _safe_read(file: UploadFile) -> bytes:
     """Return the contents of an ``UploadFile`` and reset the pointer."""

--- a/Agents/CSagent/feedback.py
+++ b/Agents/CSagent/feedback.py
@@ -1,5 +1,21 @@
 from utils.file_utils import append_row, FEEDBACK_FILE
 
+# Termen die gebruikt kunnen worden om feedback- of logfunctionaliteit op te roepen.
+TRIGGERS = {
+    "feedback",
+    "review",
+    "opmerking",
+    "logging",
+    "logboek",
+    "gebruik",
+}
+
+
+def match_terms(text: str) -> bool:
+    """Return ``True`` if the text lijkt betrekking te hebben op feedback of logging."""
+    lower = text.lower()
+    return any(t in lower for t in TRIGGERS)
+
 
 def store_feedback(user: str, feedback: str):
     append_row(FEEDBACK_FILE, [user, feedback])

--- a/Agents/CSagent/user_logging.py
+++ b/Agents/CSagent/user_logging.py
@@ -1,5 +1,12 @@
 from utils.file_utils import append_row, LOG_FILE
 
+TRIGGERS = {"gebruik", "log", "logging", "audit"}
+
+
+def match_terms(text: str) -> bool:
+    lower = text.lower()
+    return any(t in lower for t in TRIGGERS)
+
 
 def registreer_gebruik(user: str, actie: str):
     append_row(LOG_FILE, [user, actie])

--- a/Agents/Legalagent/legalcheck.py
+++ b/Agents/Legalagent/legalcheck.py
@@ -8,6 +8,24 @@ from io import BytesIO
 import pandas as pd
 from pptx import Presentation
 
+# Flexibele sleutelwoorden die de juridische module kunnen activeren.
+TRIGGERS = {
+    "juridisch",
+    "legal",
+    "ontslag",
+    "contract",
+    "vso",
+    "vaststellingsovereenkomst",
+    "arbeidsrecht",
+    "beding",
+}
+
+
+def match_terms(text: str) -> bool:
+    """Return ``True`` if juridische thema's vermoed worden in ``text``."""
+    lower = text.lower()
+    return any(t in lower for t in TRIGGERS)
+
 KEYWORDS = [
     "ontslag", "verzuim", "vso", "vaststellingsovereenkomst", "brief",
     "officiële waarschuwing", "beëindiging", "dienstverband", "adviesaanvraag",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ main.py             - definieert alle API‑routes
 agents.py           - installeert de bovengenoemde agents
 ```
 
-De `MainAgent` in `agents.py` bundelt de afzonderlijke agents en wordt gebruikt door de endpoints in `main.py`.
+De `MainAgent` in `agents.py` bundelt de afzonderlijke agents en wordt gebruikt door de endpoints in `main.py`. Daarnaast kan de `MainAgent` op basis van **semantische triggers** een passende agent selecteren. Woorden als "ontslag", "spp" of "feedback" worden automatisch gekoppeld aan de betreffende module.
 
 ### Belangrijkste agents
 

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -1,0 +1,13 @@
+from agents import MainAgent
+
+
+def test_detects_legal_agent():
+    agent = MainAgent()
+    result = agent.detect_agent("Wij hebben vragen over een ontslagprocedure")
+    assert result is agent.legal
+
+
+def test_detects_absence_agent():
+    agent = MainAgent()
+    result = agent.detect_agent("Het ziekteverzuim loopt op")
+    assert result is agent.absence


### PR DESCRIPTION
## Summary
- add flexible trigger keywords for all agent modules
- expose `match_terms` helpers and wire them into `AbsenceAgent`, `LegalAgent`, `AnalysisAgent` and `FeedbackAgent`
- implement `MainAgent.detect_agent` for semantic routing
- update README with semantic routing info
- add tests for new detection logic

## Testing
- `python -m pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792e6dc0e0832d88245b37911a6b1d