### PR TITLE
Improve legal check fallback

### DIFF
--- a/Agents/Legalagent/legalcheck.py
+++ b/Agents/Legalagent/legalcheck.py
@@ -18,6 +18,10 @@ TRIGGERS = {
     "vaststellingsovereenkomst",
     "arbeidsrecht",
     "beding",
+    # Synoniemen voor flexibele triggers
+    "casus",
+    "zaak",
+    "rechtsvraag",
 }
 
 
@@ -255,18 +259,11 @@ def legalcheck(
     intern_beleid: Optional[str] = None
 ) -> dict:
     text = extract_text_from_input(file=file, input_text=input_text)
+    status = "ok"
     if not text or len(text) < 20:
-        return {
-            "status": "onvoldoende input",
-            "advies": (
-                "De aangeleverde input is te beperkt om een juridische beoordeling te kunnen geven. "
-                "Lever meer context, een document of aanvullende informatie aan voor een grondige analyse."
-            ),
-            "actieplan": (
-                "Voeg een relevante brief, beleidsstuk of extra context toe zodat een gerichte analyse mogelijk is."
-            ),
-            "legal_markdown": "## Juridische Analyse\n**Status:** Onvoldoende input voor analyse.\n"
-        }
+        # Voer een beknopte analyse uit in plaats van direct te stoppen
+        status = "beperkte analyse"
+        text = text or (input_text or "casus")
 
     kernwoorden, juridische_begrippen = flexibele_begrippenherkenning(text)
     complexiteit = casus_complexiteit_score(kernwoorden, juridische_begrippen)
@@ -299,7 +296,7 @@ def legalcheck(
             markdown += f"- {q}\n"
 
     return {
-        "status": "ok",
+        "status": status,
         "herkenning_kernwoorden": kernwoorden,
         "herkenning_juridische_begrippen": juridische_begrippen,
         "complexiteit": complexiteit,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -77,6 +77,17 @@ def test_legalcheck_accepts_msg_file(monkeypatch):
     assert data["herkenning_kernwoorden"]
 
 
+def test_legalcheck_short_input_fallback():
+    response = client.post(
+        "/legalcheck/",
+        data={"text": "ontslag"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "beperkte analyse"
+    assert "ontslag" in data["herkenning_kernwoorden"]
+
+
 def test_upload_route_pdf_output(tmp_path):
     response = client.post(
         "/upload/?formaat=pdf",


### PR DESCRIPTION
## Summary
- expand semantic trigger words with synonyms
- allow legal check to continue with limited input
- test short input fallback scenario

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687930a90d30832d91270ffd29625a20