### PR TITLE
Enable text uploads for absence analysis

### DIFF
--- a/Agents/Absenceagent/verzuim.py
+++ b/Agents/Absenceagent/verzuim.py
@@ -32,3 +32,12 @@ def beantwoord_vraag(vraag: str, dossier: Optional[str] = None) -> str:
         "Elke situatie is uniek. Bespreek de casus met de medewerker en overweeg "
         "consultatie van de arbodienst of jurist voor passend advies."
     )
+
+
+def analyse_tekst(text: str, periode: Optional[str] = None) -> dict:
+    """Analyseer tekstuele input als ware het een document."""
+
+    from Agents.Analysisagent import analysis as analysis_mod
+
+    contents = text.encode()
+    return analysis_mod.analyse_verzuim("tekst-input", contents, periode=periode)

--- a/agents.py
+++ b/agents.py
@@ -38,10 +38,25 @@ class AbsenceAgent(BaseAgent):
     def match_terms(cls, text: str) -> bool:
         return absence_match(text)
 
-    def analyse(self, file: UploadFile, periode: Optional[str] = None) -> dict:
-        contents = file.file.read()
-        file.file.seek(0)
-        return analysis_mod.analyse_verzuim(file.filename, contents, periode=periode)
+    def analyse(
+        self,
+        file: Optional[UploadFile] = None,
+        text: Optional[str] = None,
+        periode: Optional[str] = None,
+    ) -> dict:
+        """Analyseer een verzuimdocument of tekst."""
+
+        if file is None and text is None:
+            raise ValueError("file of text verplicht")
+
+        if file is not None:
+            contents = file.file.read()
+            file.file.seek(0)
+            filename = file.filename
+        else:
+            contents = text.encode()
+            filename = "tekst-input"
+        return analysis_mod.analyse_verzuim(filename, contents, periode=periode)
 
     def analyse_batch(self, files: List[UploadFile], periode: Optional[str] = None) -> List[dict]:
         items: List[Tuple[str, bytes]] = []

--- a/main.py
+++ b/main.py
@@ -12,11 +12,14 @@ main_agent = MainAgent()
 
 @app.post("/upload/")
 async def upload_file(
-    file: UploadFile = File(...),
+    file: UploadFile = File(None),
+    text: Optional[str] = Form(None),
     periode: Optional[str] = None,
     formaat: Optional[str] = "json",
 ):
-    result = main_agent.absence.analyse(file, periode)
+    if file is None and text is None:
+        return JSONResponse(status_code=400, content={"error": "file of text vereist"})
+    result = main_agent.absence.analyse(file=file, text=text, periode=periode)
     if formaat == "pdf":
         markdown = (
             f"# Verzuimrapport\n"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -106,3 +106,13 @@ def test_upload_route_chart_output(tmp_path):
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
+
+def test_upload_route_text_input():
+    response = client.post(
+        "/upload/",
+        data={"text": "ziekmelding wegens griep"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["filename"] == "tekst-input"
+


### PR DESCRIPTION
## Summary
- allow absence analysis to handle plain text
- accept `text` input for `/upload/` route
- test text input for the upload route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a01c91c90832db17d1e49fb424ecf