### PR TITLE
Enable text uploads for absence analysis

### DIFF
--- a/Agents/Absenceagent/verzuim.py
+++ b/Agents/Absenceagent/verzuim.py
@@ -32,3 +32,12 @@ def beantwoord_vraag(vraag: str, dossier: Optional[str] = None) -> str:
         "Elke situatie is uniek. Bespreek de casus met de medewerker en overweeg "
         "consultatie van de arbodienst of jurist voor passend advies."
     )
+
+
+def analyse_tekst(text: str, periode: Optional[str] = None) -> dict:
+    """Analyseer tekstuele input als ware het een document."""
+
+    from Agents.Analysisagent import analysis as analysis_mod
+
+    contents = text.encode()
+    return analysis_mod.analyse_verzuim("tekst-input", contents, periode=periode)

--- a/Agents/Analysisagent/analysis.py
+++ b/Agents/Analysisagent/analysis.py
@@ -240,7 +240,13 @@ def analyse_spp(file: Optional[UploadFile] = None, text: Optional[str] = None) -
     elif text is not None:
         df = pd.read_csv(StringIO(text))
     else:
-        raise ValueError("Geen input opgegeven")
+        return {
+            "status": "geen input",
+            "grid": {},
+            "risico": "onbekend",
+            "acties": [],
+            "adviezen": [],
+        }
 
     grid_keys = [
         "laag_potentieel_lage_prestatie",

--- a/main.py
+++ b/main.py
@@ -12,11 +12,14 @@ main_agent = MainAgent()
 
 @app.post("/upload/")
 async def upload_file(
-    file: UploadFile = File(...),
+    file: UploadFile = File(None),
+    text: Optional[str] = Form(None),
     periode: Optional[str] = None,
     formaat: Optional[str] = "json",
 ):
-    result = main_agent.absence.analyse(file, periode)
+    result = main_agent.absence.analyse(file=file, text=text, periode=periode)
+    if result.get("status") == "geen input":
+        return JSONResponse(content=result)
     if formaat == "pdf":
         markdown = (
             f"# Verzuimrapport\n"

--- a/tests/test_new_routes.py
+++ b/tests/test_new_routes.py
@@ -99,3 +99,10 @@ def test_legalcheck_risk_and_sources():
     for hits in data["bronnen"].values():
         for url, _ in hits:
             assert url.startswith("http")
+
+
+def test_spp_route_no_input():
+    response = client.post("/spp/?formaat=json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "geen input"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -106,3 +106,20 @@ def test_upload_route_chart_output(tmp_path):
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
+
+def test_upload_route_text_input():
+    response = client.post(
+        "/upload/",
+        data={"text": "ziekmelding wegens griep"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["filename"] == "tekst-input"
+
+
+def test_upload_route_no_input():
+    response = client.post("/upload/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "geen input"
+


### PR DESCRIPTION
## Summary
- allow absence analysis to handle plain text
- accept `text` input for `/upload/` route
- test text input for the upload route
- return friendly status if no input is provided

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a01c91c90832db17d1e49fb424ecf