### PR TITLE
Add disclaimers in docs and output

### DIFF
--- a/Agents/Analysisagent/analysis.py
+++ b/Agents/Analysisagent/analysis.py
@@ -6,6 +6,12 @@ from datetime import datetime
 import random
 from utils.file_utils import append_row, LOG_FILE
 
+# Disclaimer voor gebruikers van analysetools
+ANALYSE_DISCLAIMER = (
+    "Dit resultaat vormt een algemeen advies op basis van de ingevoerde gegevens. "
+    "Het is niet bindend en kan geen individueel consult vervangen."
+)
+
 # Kernwoorden die verwijzen naar algemene analysefuncties. Deze lijst wordt
 # gebruikt om op basis van semantiek het juiste onderdeel aan te roepen.
 TRIGGERS = {
@@ -61,6 +67,7 @@ def analyse_bestand(file: UploadFile, vraag: str) -> dict:
         "risico": risico,
         "scenario": scenario,
         "aanbevelingen": aanbevelingen,
+        "disclaimer": ANALYSE_DISCLAIMER,
     }
 
 
@@ -166,6 +173,7 @@ def analyse_verzuim(
         "advies": advies,
         "beleidsadvies": beleidsadvies,
         "resultaat": "Analyse nog niet geïmplementeerd",
+        "disclaimer": ANALYSE_DISCLAIMER,
     }
 
 
@@ -246,6 +254,7 @@ def analyse_spp(file: Optional[UploadFile] = None, text: Optional[str] = None) -
             "risico": "onbekend",
             "acties": [],
             "adviezen": [],
+            "disclaimer": ANALYSE_DISCLAIMER,
         }
 
     grid_keys = [
@@ -299,6 +308,7 @@ def analyse_spp(file: Optional[UploadFile] = None, text: Optional[str] = None) -
         "risico": risico,
         "acties": acties,
         "adviezen": adviezen,
+        "disclaimer": ANALYSE_DISCLAIMER,
     }
 
 

--- a/Agents/Legalagent/legalcheck.py
+++ b/Agents/Legalagent/legalcheck.py
@@ -8,6 +8,12 @@ from io import BytesIO
 import pandas as pd
 from pptx import Presentation
 
+# Disclaimer voor juridische adviezen
+LEGAL_DISCLAIMER = (
+    "Dit resultaat is een algemeen juridisch advies op basis van de aangeleverde informatie. "
+    "Het is niet bindend en vervangt geen individueel consult met een specialist."
+)
+
 # Flexibele sleutelwoorden die de juridische module kunnen activeren.
 TRIGGERS = {
     "juridisch",
@@ -294,6 +300,7 @@ def legalcheck(
         markdown += "\n**Vervolgvragen:**\n"
         for q in vragen:
             markdown += f"- {q}\n"
+    markdown += f"\n**Disclaimer:** {LEGAL_DISCLAIMER}\n"
 
     return {
         "status": status,
@@ -305,5 +312,6 @@ def legalcheck(
         "bronnen": bronnen,
         "verdiepende_vragen": vragen,
         "risico": risico,
-        "legal_markdown": markdown
+        "legal_markdown": markdown,
+        "disclaimer": LEGAL_DISCLAIMER,
     }

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ pytest
 ## Privacyverklaring
 
 Zie `privacyverklaring.txt` voor een toelichting op het tijdelijke gebruik van geüploade documenten. Er worden geen gegevens opgeslagen of gedeeld met derden.
+
+## Disclaimer
+
+De resultaten van deze applicatie vormen algemeen HR- en juridisch advies op basis van de aangeleverde gegevens. Ze zijn niet bindend en kunnen een individueel consult bij een specialist niet vervangen. De ontwikkelaars aanvaarden geen aansprakelijkheid voor handelingen die worden verricht naar aanleiding van de output. Gebruik geen vertrouwelijke persoonsgegevens en volg de privacyverklaring.

--- a/privacyverklaring.txt
+++ b/privacyverklaring.txt
@@ -3,3 +3,4 @@ Privacyverklaring Verzuimanalyse Module
 Deze applicatie verwerkt documenten enkel tijdelijk voor analyse. 
 Er worden geen gegevens opgeslagen of gedeeld met derden. 
 Gebruikers zijn verantwoordelijk voor het anonimiseren van gevoelige informatie.
+Het resultaat van de analysetools vormt een algemeen HR- en juridisch advies. Het is niet bindend en kan geen persoonlijke beoordeling door een professional vervangen. De gebruiker blijft zelf verantwoordelijk voor naleving van toepasselijke wet- en regelgeving.


### PR DESCRIPTION
## Summary
- include general disclaimer section in README
- note in privacy policy that outputs are not legal advice
- return disclaimers from analysis and legal modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b6195d6fc832dad4b54343a17bd7a