### PR TITLE
Add persistent memory and feedback tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .pytest_cache/
 utils/*.csv
+utils/memory.json

--- a/main.py
+++ b/main.py
@@ -108,5 +108,6 @@ async def auto_route(
         actie=actie,
         periode=periode,
         formaat=formaat,
+        user=gebruiker,
     )
     return JSONResponse(content=result)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,17 @@
+from agents import MainAgent
+from utils.memory import Memory
+
+
+def test_memory_persistence(tmp_path):
+    path = tmp_path / "mem.json"
+    mem = Memory(path)
+    mem.add("user", {"data": 1})
+    mem2 = Memory(path)
+    assert mem2.get("user")[0]["data"] == 1
+
+
+def test_main_agent_stores_in_memory(tmp_path):
+    path = tmp_path / "mem.json"
+    agent = MainAgent(memory_path=path)
+    agent.auto_route("Het ziekteverzuim neemt toe", user="tester")
+    assert agent.memory.get("tester")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
 from .text_utils import text_matches
+from .memory import Memory

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime
+
+UTILS_DIR = Path(__file__).resolve().parent
+MEMORY_FILE = UTILS_DIR / "memory.json"
+
+
+class Memory:
+    """Simple persistent memory storage using a JSON file."""
+
+    def __init__(self, path: Path | None = None):
+        self.path = path or MEMORY_FILE
+        self.data: dict[str, list[dict]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            try:
+                self.data = json.loads(self.path.read_text())
+            except Exception:
+                self.data = {}
+        else:
+            self.data = {}
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.data))
+
+    def add(self, user: str, entry: dict) -> None:
+        """Add an entry for ``user`` and persist it."""
+        self.data.setdefault(user, []).append(
+            {"timestamp": datetime.utcnow().isoformat(), **entry}
+        )
+        self._save()
+
+    def get(self, user: str) -> list[dict]:
+        return self.data.get(user, [])


### PR DESCRIPTION
## Summary
- introduce `Memory` util for persistent storage
- hook memory into all agents and `MainAgent`
- store user input/output in memory from API
- test memory persistence and integration
- ignore generated `utils/memory.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd7b6d1ac832d8f4062bb5b7cf618