### PR TITLE
Add workflow agent

### DIFF
--- a/Agents/Workflowagent/__init__.py
+++ b/Agents/Workflowagent/__init__.py
@@ -1,0 +1,1 @@
+from .workflow import WorkflowAgent, TRIGGERS

--- a/Agents/Workflowagent/workflow.py
+++ b/Agents/Workflowagent/workflow.py
@@ -1,0 +1,34 @@
+from typing import List, Optional
+from utils import text_matches
+from agents import BaseAgent
+
+TRIGGERS = {"workflow", "plan", "stap", "procedure"}
+
+class WorkflowAgent(BaseAgent):
+    """Agent die stapsgewijs andere agents kan aanroepen."""
+
+    name = "workflow"
+    TRIGGERS = TRIGGERS
+
+    @classmethod
+    def match_terms(cls, text: str) -> bool:
+        return text_matches(text, cls.TRIGGERS)
+
+    def handle(self, *, text: str | None = None, user: str | None = None, context: Optional[dict] = None, **kw) -> dict:
+        if not text:
+            return {"status": "geen input"}
+
+        steps = [s.strip() for s in text.splitlines() if s.strip()]
+        ctx = context or {}
+        results: List[dict] = []
+        for step in steps:
+            agent = self.orchestrator.detect_agent(step)
+            if agent:
+                res = agent.handle(text=step, context=ctx, user=user, **kw)
+                ctx[agent.name] = res
+                results.append({"stap": step, "agent": agent.name, "resultaat": res})
+            else:
+                results.append({"stap": step, "agent": None, "resultaat": {"status": "geen match"}})
+        if user and self.orchestrator:
+            self.orchestrator.memory.add(user, {"workflow": results})
+        return {"stappen": results}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Agents/
   Analysisagent/    - generieke bestand‑ en SPP‑analyses
   CSagent/          - feedback en gebruiksregistratie
   Legalagent/       - juridische controles
+  Workflowagent/    - stapsgewijze aansturing van andere agents
 utils/              - hulpfuncties voor opslag van feedback en logs
 main.py             - definieert alle API‑routes
 agents.py           - installeert de bovengenoemde agents
@@ -30,6 +31,9 @@ De `MainAgent` in `agents.py` bundelt de afzonderlijke agents en wordt gebruikt 
    - Resultaten kunnen als JSON, Excel of CSV worden teruggegeven.
 4. **FeedbackAgent** (`Agents/CSagent/`)
    - Slaat feedback op en registreert gebruiksacties. Alleen de beheerder mag deze routes aanroepen.
+5. **WorkflowAgent** (`Agents/Workflowagent/`)
+   - Voert een lijst stappen uit en kiest per stap automatisch de meest geschikte agent.
+   - Resultaat is een overzicht van alle uitgevoerde acties per stap.
 
 ## API‑endpoints
 

--- a/agents.py
+++ b/agents.py
@@ -37,6 +37,7 @@ from Agents.Absenceagent.verzuim import (
     TRIGGERS as ABSENCE_TRIGGERS,
     match_terms as absence_match,
 )
+from Agents.Workflowagent.workflow import WorkflowAgent, TRIGGERS as WORKFLOW_TRIGGERS
 
 
 class AbsenceAgent(BaseAgent):
@@ -217,7 +218,14 @@ class MainAgent:
         self.legal = LegalAgent(self)
         self.analysis = AnalysisAgent(self)
         self.feedback = FeedbackAgent(self)
-        self.agents = [self.legal, self.absence, self.analysis, self.feedback]
+        self.workflow = WorkflowAgent(self)
+        self.agents = [
+            self.legal,
+            self.absence,
+            self.analysis,
+            self.feedback,
+            self.workflow,
+        ]
 
     def detect_agent(self, text: str) -> Optional[BaseAgent]:
         """Kies een agent op basis van semantische triggers."""

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -11,3 +11,9 @@ def test_detects_absence_agent():
     agent = MainAgent()
     result = agent.detect_agent("Het ziekteverzuim loopt op")
     assert result is agent.absence
+
+
+def test_detects_workflow_agent():
+    agent = MainAgent()
+    result = agent.detect_agent("workflow stappen")
+    assert result is agent.workflow

--- a/tests/test_workflow_agent.py
+++ b/tests/test_workflow_agent.py
@@ -1,0 +1,10 @@
+from agents import MainAgent
+
+
+def test_workflow_handles_multiple_steps():
+    agent = MainAgent()
+    result = agent.workflow.handle(text="Ontslag traject\nVerzuim stijgt")
+    steps = result["stappen"]
+    assert len(steps) == 2
+    assert steps[0]["agent"] == "legal"
+    assert steps[1]["agent"] == "absence"


### PR DESCRIPTION
## Summary
- implement a `WorkflowAgent` for stepwise orchestration
- connect the new agent in `MainAgent`
- document the new agent in README
- test semantic detection and workflow behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cbeb21f5c832da874ec8986b6f4be