### PR TITLE
Add per-agent test logs

### DIFF
--- a/log_absence.txt
+++ b/log_absence.txt
@@ -1,0 +1,8 @@
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 1.14s

--- a/log_analysis.txt
+++ b/log_analysis.txt
@@ -1,0 +1,8 @@
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 0.72s

--- a/log_compliance.txt
+++ b/log_compliance.txt
@@ -1,0 +1,8 @@
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 0.88s

--- a/log_feedback.txt
+++ b/log_feedback.txt
@@ -1,0 +1,8 @@
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 0.70s

--- a/log_legal.txt
+++ b/log_legal.txt
@@ -1,0 +1,8 @@
+.                                                                        [100%]
+=============================== warnings summary ===============================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:10: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1 passed, 1 warning in 0.70s


### PR DESCRIPTION
## Summary
- run tests for each agent and save their outputs in separate logs

## Testing
- `pytest tests/test_routes.py::test_upload_route_returns_analysis_dict -q`
- `pytest tests/test_routes.py::test_legalcheck_route_with_keywords -q`
- `pytest tests/test_new_routes.py::test_analyse_route_returns_json -q`
- `pytest tests/test_routes.py::test_compliance_route_detects_terms -q`
- `pytest tests/test_new_routes.py::test_feedback_route_with_admin -q`


------
https://chatgpt.com/codex/tasks/task_e_687cbf33a1d0832d8ce3fa1af2bc7778