### PR TITLE
Improve agent modules with n8n payloads

### DIFF
--- a/Agents/Absenceagent/verzuim.py
+++ b/Agents/Absenceagent/verzuim.py
@@ -1,7 +1,7 @@
 """Functies voor het behandelen van verzuimcasuïstiek en vragen."""
 from typing import Optional
 
-from utils import text_matches
+from utils import text_matches, format_payload
 
 # Kernwoorden die semantisch gerelateerd zijn aan verzuim. Worden gebruikt om
 # te bepalen of deze module relevant is voor een binnengekomen vraag.
@@ -42,3 +42,26 @@ def analyse_tekst(text: str, periode: Optional[str] = None) -> dict:
 
     contents = text.encode()
     return analysis_mod.analyse_verzuim("tekst-input", contents, periode=periode)
+
+
+def advies_niveaus(vraag: str, dossier: Optional[str] = None) -> dict:
+    """Geef advies op operationeel, tactisch en strategisch niveau."""
+
+    basis = beantwoord_vraag(vraag, dossier)
+    return {
+        "operationeel": basis,
+        "tactisch": (
+            "Analyseer verzuimpatronen, stem af met leidinggevenden en stuur bij "
+            "waar nodig."
+        ),
+        "strategisch": (
+            "Koppel verzuimcijfers aan bedrijfsdoelen en ontwikkel preventief beleid."
+        ),
+    }
+
+
+def n8n_payload(vraag: str, dossier: Optional[str] = None) -> dict:
+    """Retourneer een n8n-geschikte payload met adviesniveaus."""
+
+    data = advies_niveaus(vraag, dossier)
+    return format_payload("verzuim", data)

--- a/Agents/Analysisagent/analysis.py
+++ b/Agents/Analysisagent/analysis.py
@@ -1,6 +1,6 @@
 from fastapi import UploadFile
 from typing import Iterable, List, Tuple, Optional, Dict
-from utils import text_matches
+from utils import text_matches, format_payload
 import pandas as pd
 from io import BytesIO, StringIO
 from datetime import datetime
@@ -67,6 +67,7 @@ def analyse_bestand(file: UploadFile, vraag: str) -> dict:
         "risico": risico,
         "scenario": scenario,
         "aanbevelingen": aanbevelingen,
+        "niveaus": advies_niveaus(risico),
         "disclaimer": ANALYSE_DISCLAIMER,
     }
 
@@ -132,6 +133,22 @@ def genereer_aanbevelingen(risico: str) -> str:
     return f"Mogelijke vervolgstappen: {adviezen}"
 
 
+def advies_niveaus(risico: str) -> Dict[str, str]:
+    """Geef advies op meerdere niveaus voor het opgegeven risiconiveau."""
+
+    return {
+        "operationeel": (
+            "Controleer de datakwaliteit en leg afwijkingen direct vast."
+        ),
+        "tactisch": (
+            f"Gebruik de analyse om processen te verbeteren bij een {risico} risico."
+        ),
+        "strategisch": (
+            "Zet datagedreven inzichten om in beleid voor de lange termijn."
+        ),
+    }
+
+
 def haal_branchenorm(periode: str | None = None) -> dict:
     """Simuleer een algemene branchenorm zonder specifieke codes."""
 
@@ -172,6 +189,7 @@ def analyse_verzuim(
         "risico": risico,
         "advies": advies,
         "beleidsadvies": beleidsadvies,
+        "niveaus": advies_niveaus(risico),
         "resultaat": "Analyse nog niet geïmplementeerd",
         "disclaimer": ANALYSE_DISCLAIMER,
     }
@@ -308,6 +326,7 @@ def analyse_spp(file: Optional[UploadFile] = None, text: Optional[str] = None) -
         "risico": risico,
         "acties": acties,
         "adviezen": adviezen,
+        "niveaus": advies_niveaus(risico),
         "disclaimer": ANALYSE_DISCLAIMER,
     }
 
@@ -325,3 +344,9 @@ def genereer_spp_rapport(data: Dict, formaat: str = "excel") -> BytesIO:
 
 def log_spp(user: str, actie: str):
     append_row(LOG_FILE, [user, actie])
+
+
+def n8n_payload(data: Dict) -> Dict:
+    """Return an n8n friendly payload for analysis resultaten."""
+
+    return format_payload("analysis", data)

--- a/Agents/Complianceagent/compliance.py
+++ b/Agents/Complianceagent/compliance.py
@@ -1,6 +1,6 @@
 from fastapi import UploadFile
 from typing import Optional
-from utils import text_matches
+from utils import text_matches, format_payload
 from io import BytesIO
 import pandas as pd
 import extract_msg
@@ -76,6 +76,16 @@ def detect_pii(text: str) -> list[str]:
     return list(set(emails + numbers))
 
 
+def advies_niveaus(status: str) -> dict:
+    """Geef advies op operationeel, tactisch en strategisch niveau."""
+
+    return {
+        "operationeel": "Controleer direct op mogelijke datalekken en corrigeer documenten.",
+        "tactisch": "Borg naleving van interne privacyprocedures en train medewerkers.",
+        "strategisch": "Veranker privacy- en beveiligingsbeleid in de bedrijfsstrategie.",
+    }
+
+
 def compliance_check(file: Optional[UploadFile] = None, text: Optional[str] = None) -> dict:
     content = extract_text(file=file, text=text)
     if not content:
@@ -90,4 +100,12 @@ def compliance_check(file: Optional[UploadFile] = None, text: Optional[str] = No
         "gevonden_termen": hits,
         "gevonden_pii": pii,
         "advies": advies,
+        "niveaus": advies_niveaus(status),
     }
+
+
+def n8n_payload(file: Optional[UploadFile] = None, text: Optional[str] = None) -> dict:
+    """Retourneer een n8n-vriendelijk payloadresultaat."""
+
+    data = compliance_check(file=file, text=text)
+    return format_payload("compliance", data)

--- a/Agents/Legalagent/legalcheck.py
+++ b/Agents/Legalagent/legalcheck.py
@@ -1,7 +1,7 @@
 
 from fastapi import UploadFile
 from typing import List, Optional, Tuple
-from utils import text_matches
+from utils import text_matches, format_payload
 import tempfile
 import os
 import extract_msg
@@ -259,6 +259,20 @@ def generate_legal_advice(
     vragen = genereer_vragen(kernwoorden, juridische_begrippen)
     return advies, actieplan, vragen, risico
 
+
+def advies_niveaus(complexiteit: str) -> dict:
+    """Advies op operationeel, tactisch en strategisch niveau."""
+
+    return {
+        "operationeel": "Controleer dossier en zorg voor juiste documentatie.",
+        "tactisch": (
+            "Weeg belangen zorgvuldig af en betrek tijdig interne specialisten."
+        ),
+        "strategisch": (
+            "Borg dat het juridische kader aansluit bij het HR-beleid en toekomstplannen."
+        ),
+    }
+
 def legalcheck(
     file: Optional[UploadFile] = None,
     input_text: Optional[str] = None,
@@ -312,6 +326,14 @@ def legalcheck(
         "bronnen": bronnen,
         "verdiepende_vragen": vragen,
         "risico": risico,
+        "niveaus": advies_niveaus(complexiteit),
         "legal_markdown": markdown,
         "disclaimer": LEGAL_DISCLAIMER,
     }
+
+
+def n8n_payload(file: Optional[UploadFile] = None, text: Optional[str] = None, intern_beleid: Optional[str] = None) -> dict:
+    """Retourneer een n8n-geschikte payload voor juridische checks."""
+
+    data = legalcheck(file=file, input_text=text, intern_beleid=intern_beleid)
+    return format_payload("legal", data)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,3 @@
 from .text_utils import text_matches
 from .memory import Memory
+from .n8n import format_payload

--- a/utils/n8n.py
+++ b/utils/n8n.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from typing import Any, Dict
+
+
+def format_payload(module: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a simple payload structure for n8n workflows."""
+    return {
+        "module": module,
+        "timestamp": datetime.utcnow().isoformat(),
+        "data": data,
+    }


### PR DESCRIPTION
## Summary
- extend Absenceagent, Analysisagent, Legalagent and Complianceagent with
  operational/tactical/strategic advice
- add helper to create standard n8n payloads
- expose `format_payload` via utils

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebad55018832d9b8be95a0e558d03